### PR TITLE
fix(sarif): correct group-as validation errors

### DIFF
--- a/sarif/sarif-module.xml
+++ b/sarif/sarif-module.xml
@@ -124,7 +124,6 @@
         <model>
             <assembly ref="toolComponent">
                 <use-name>driver</use-name>
-                <group-as name="driver"  />
             </assembly>
         </model>
     </define-assembly>
@@ -204,7 +203,7 @@
                 <formal-name>Occurrence Count</formal-name>
                 <description>A positive integer specifying the number of times this logically unique result was observed in this run.</description>
             </define-field>
-            <assembly ref="location" min-occurs="0">
+            <assembly ref="location" min-occurs="0" max-occurs="unbounded">
                 <formal-name>Result Related Location</formal-name>
                 <description>A set of locations relevant to this result.</description>
                 <use-name>relatedLocation</use-name>


### PR DESCRIPTION
## Summary
- Remove `group-as` from driver field (single object, not an array per SARIF 2.1.0 schema)
- Add `max-occurs="unbounded"` to relatedLocations (is an array per SARIF 2.1.0 schema)

## Test plan
- [x] Verified against sarif-schema-2.1.0.json that driver is a single object and relatedLocations is an array
- [x] Build passes with `mvn install -PCI -Prelease`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Results now support multiple related locations per result, enabling richer context information and improved cross-referencing capabilities.

* **Improvements**
  * Streamlined tool definition structure to enhance consistency and reduce unnecessary public exposure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->