### PR TITLE
docs: add formal-name and description to toolComponent assembly

### DIFF
--- a/sarif/sarif-module.xml
+++ b/sarif/sarif-module.xml
@@ -30,6 +30,8 @@
 		</model>
     </define-assembly>
     <define-assembly name="toolComponent">
+        <formal-name>Tool Component</formal-name>
+        <description>A component, such as a plug-in or the driver, of the analysis tool that was run.</description>
         <define-flag name="guid" as-type="uuid">
             <formal-name>Tool Component Unique Identifier</formal-name>
             <description>A stable, unique identifier for the tool component.</description>


### PR DESCRIPTION
## Summary
- Add missing `formal-name` and `description` elements to the `toolComponent` assembly definition in the SARIF module

## Test plan
- [ ] Verify the module still validates correctly
- [ ] Regenerate any dependent bindings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the SARIF schema with additional formal metadata for the Tool Component, including a formal name and descriptive information clarifying that it represents analysis tool components such as plug-ins or drivers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->