### PR TITLE
feat(sarif): add per-result timing extensions to SARIF module

### DIFF
--- a/sarif/sarif-module.xml
+++ b/sarif/sarif-module.xml
@@ -32,6 +32,11 @@
 	            <description>Performance timing measurements for the associated item.</description>
 	            <use-name>timing</use-name>
 	        </assembly>
+	        <assembly ref="letTimingEntry" min-occurs="0" max-occurs="unbounded">
+	            <formal-name>Let Statement Timings</formal-name>
+	            <description>Per-let-statement timing data for the associated constraint evaluation.</description>
+	            <group-as name="letTimings" in-json="ARRAY"/>
+	        </assembly>
 	        <any/>
 		</model>
     </define-assembly>
@@ -55,6 +60,21 @@
                 <formal-name>Maximum Duration (ms)</formal-name>
                 <description>Maximum single-invocation duration in milliseconds.</description>
             </define-field>
+        </model>
+    </define-assembly>
+    <define-assembly name="letTimingEntry">
+        <formal-name>Let Statement Timing Entry</formal-name>
+        <description>Timing data for a single let-statement evaluation.</description>
+        <define-flag name="name" required="yes">
+            <formal-name>Let Statement Name</formal-name>
+            <description>The name of the let-statement variable.</description>
+        </define-flag>
+        <model>
+            <assembly ref="timingData">
+                <formal-name>Timing Data</formal-name>
+                <description>Performance timing measurements for this let-statement.</description>
+                <use-name>timing</use-name>
+            </assembly>
         </model>
     </define-assembly>
     <define-assembly name="toolComponent">
@@ -248,6 +268,11 @@
                 <formal-name>Result Provenance</formal-name>
                 <description>Information about how and when the result was detected.</description>
                 <use-name>provenance</use-name>
+            </assembly>
+            <assembly ref="propertyBag" min-occurs="0">
+                <formal-name>Properties</formal-name>
+                <description>Key/value pairs that provide additional information about the result.</description>
+                <use-name>properties</use-name>
             </assembly>
         </model>
         <constraint>


### PR DESCRIPTION
## Summary

Extends the SARIF Metaschema module with per-result timing support for constraint processing instrumentation (#314 in metaschema-java).

### Changes to `sarif-module.xml`

- Add `propertyBag` assembly reference to `result` definition for per-result extensibility
- Add `letTimingEntry` assembly definition with `name` flag and `timingData` reference
- Add `letTimings` list (array of `letTimingEntry`) to `PropertyBag` model

These additions enable:
- Per-result constraint evaluation timing via `result.properties.timing`
- Per-result let-statement timing via `result.properties.letTimings`

All changes use the standard SARIF 2.1.0 `propertyBag` extensibility mechanism (section 3.8).

## Test Plan

- [x] SARIF output with per-result timing validates against official SARIF 2.1.0 JSON schema
- [x] Generated binding classes compile and pass all tests
- [x] Full CI build passes in metaschema-java

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-let-statement timing data collection through a new letTimingEntry structure.
  * Results now support attached properties for enhanced metadata and additional context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->